### PR TITLE
--at-once odb feature and windows support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,17 +41,9 @@ endif()
 add_executable(odbcmake
 	${OdbCMake_SOURCES}
 	${OdbCMake_ODB_HEADERS})
-	
-if(AT_ONCE)
-	# trivial definitions for linux g++ and windows VC++
-	# correct for your compiler
-	if(NOT ${CMAKE_SYSTEM_NAME} MATCHES "Windows")
-		set_target_properties(odbcmake PROPERTIES COMPILE_FLAGS " -DAT_ONCE ")
-	else()
-		set_target_properties(odbcmake PROPERTIES COMPILE_FLAGS " /D AT_ONCE ")
-	endif()
-endif()
-	
+
+target_compile_definitions(odbcmake PUBLIC AT_ONCE)
+
 target_link_libraries(odbcmake
 	${ODB_LIBRARIES})
 target_include_directories(odbcmake

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,10 @@ cmake_minimum_required(VERSION 2.8.12)
 
 project(OdbCMake)
 
+option (AT_ONCE "Build all structures into one file." FALSE)
+
+set(TARGET_DB "sqlite")
+
 # windows section - generate paths based on ODB_ROOT 
 if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
 	if(DEFINED ENV{ODB_ROOT})
@@ -16,7 +20,7 @@ endif(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/Modules")
 
-find_package(ODB REQUIRED COMPONENTS mysql OPTIONAL_COMPONENTS pgsql)
+find_package(ODB REQUIRED COMPONENTS ${TARGET_DB} OPTIONAL_COMPONENTS pgsql)
 include(${ODB_USE_FILE})
 
 set(OdbCMake_SOURCES
@@ -27,11 +31,27 @@ set(OdbCMake_ODB_HEADERS
 	person.h
   employee.h)
 
-odb_compile(OdbCMake_SOURCES FILES ${OdbCMake_ODB_HEADERS} DB mysql GENERATE_QUERY GENERATE_SESSION INPUT_NAME "personal")
+if (AT_ONCE)
+	message(STATUS "All database code in one file personal_*")
+	odb_compile(OdbCMake_SOURCES FILES ${OdbCMake_ODB_HEADERS} DB ${TARGET_DB} GENERATE_QUERY GENERATE_SESSION INPUT_NAME "personal")
+else()
+	odb_compile(OdbCMake_SOURCES FILES ${OdbCMake_ODB_HEADERS} DB ${TARGET_DB} GENERATE_QUERY GENERATE_SESSION)
+endif()
 
 add_executable(odbcmake
 	${OdbCMake_SOURCES}
 	${OdbCMake_ODB_HEADERS})
+	
+if(AT_ONCE)
+	# trivial definitions for linux g++ and windows VC++
+	# correct for your compiler
+	if(NOT ${CMAKE_SYSTEM_NAME} MATCHES "Windows")
+		set_target_properties(odbcmake PROPERTIES COMPILE_FLAGS " -D AT_ONCE ")
+	else()
+		set_target_properties(odbcmake PROPERTIES COMPILE_FLAGS " /D AT_ONCE ")
+	endif()
+endif()
+	
 target_link_libraries(odbcmake
 	${ODB_LIBRARIES})
 target_include_directories(odbcmake

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,18 +6,6 @@ option (AT_ONCE "Build all structures into one file." FALSE)
 
 set(TARGET_DB "sqlite")
 
-# windows section - generate paths based on ODB_ROOT 
-if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
-	if(DEFINED ENV{ODB_ROOT})
-		set(ODB_ROOT $ENV{ODB_ROOT})
-	endif(DEFINED ENV{ODB_ROOT})
-    message(STATUS "Prepare variables using ODB_ROOT=${ODB_ROOT}")
-	set(PC_LIBODB_INCLUDE_DIRS "${ODB_ROOT}\\include")
-	set(PC_LIBODB_LIBRARY_DIRS "${ODB_ROOT}\\lib")
-	set(ODB_LIBODB_INCLUDE_DIRS "${ODB_ROOT}\\include")
-	set(ODB_LIBRARY_PATH "${ODB_ROOT}\\lib")
-endif(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
-
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/Modules")
 
 find_package(ODB REQUIRED COMPONENTS ${TARGET_DB} OPTIONAL_COMPONENTS pgsql)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,7 +46,7 @@ if(AT_ONCE)
 	# trivial definitions for linux g++ and windows VC++
 	# correct for your compiler
 	if(NOT ${CMAKE_SYSTEM_NAME} MATCHES "Windows")
-		set_target_properties(odbcmake PROPERTIES COMPILE_FLAGS " -D AT_ONCE ")
+		set_target_properties(odbcmake PROPERTIES COMPILE_FLAGS " -DAT_ONCE ")
 	else()
 		set_target_properties(odbcmake PROPERTIES COMPILE_FLAGS " /D AT_ONCE ")
 	endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ endif(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/Modules")
 
-find_package(ODB REQUIRED COMPONENTS sqlite OPTIONAL_COMPONENTS mysql pgsql)
+find_package(ODB REQUIRED COMPONENTS mysql OPTIONAL_COMPONENTS pgsql)
 include(${ODB_USE_FILE})
 
 set(OdbCMake_SOURCES
@@ -24,9 +24,10 @@ set(OdbCMake_SOURCES
 	database.h)
 
 set(OdbCMake_ODB_HEADERS
-	person.h)
+	person.h
+  employee.h)
 
-odb_compile(OdbCMake_SOURCES FILES ${OdbCMake_ODB_HEADERS} DB sqlite GENERATE_QUERY GENERATE_SESSION)
+odb_compile(OdbCMake_SOURCES FILES ${OdbCMake_ODB_HEADERS} DB mysql GENERATE_QUERY GENERATE_SESSION INPUT_NAME "personal")
 
 add_executable(odbcmake
 	${OdbCMake_SOURCES}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,9 +2,21 @@ cmake_minimum_required(VERSION 2.8.12)
 
 project(OdbCMake)
 
+# windows section - generate paths based on ODB_ROOT 
+if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
+	if(DEFINED ENV{ODB_ROOT})
+		set(ODB_ROOT $ENV{ODB_ROOT})
+	endif(DEFINED ENV{ODB_ROOT})
+    message(STATUS "Prepare variables using ODB_ROOT=${ODB_ROOT}")
+	set(PC_LIBODB_INCLUDE_DIRS "${ODB_ROOT}\\include")
+	set(PC_LIBODB_LIBRARY_DIRS "${ODB_ROOT}\\lib")
+	set(ODB_LIBODB_INCLUDE_DIRS "${ODB_ROOT}\\include")
+	set(ODB_LIBRARY_PATH "${ODB_ROOT}\\lib")
+endif(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
+
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/Modules")
 
-find_package(ODB REQUIRED COMPONENTS qt sqlite OPTIONAL_COMPONENTS mysql pgsql)
+find_package(ODB REQUIRED COMPONENTS sqlite OPTIONAL_COMPONENTS mysql pgsql)
 include(${ODB_USE_FILE})
 
 set(OdbCMake_SOURCES

--- a/README
+++ b/README
@@ -1,7 +1,7 @@
 CMake Find Module and UseFile for ODB.
 
 ### Windows ODB installation notes:
-Install all odb components into some directory and setup environment variable ODB_ROOT=your_odb_installation_directory. 
+Install all odb components into some directory and setup environment variable CMAKE_PREFIX_PATH=your_odb_installation_directory. 
 Directory must contain sub-directories bin for executables(especially odb.exe) and dlls, 
 include/odb for odb headers and lib for lib files. 
 For example c:\odb\bin, c\odb\include and c:\odb\lib. Note: when you copy odb.exe - do not copy only exe file - you need all directories from archive.

--- a/README
+++ b/README
@@ -1,11 +1,12 @@
 CMake Find Module and UseFile for ODB.
 
 ### Windows ODB installation notes:
-Install all odb components into some directory and setup environment variable ODB_ROOT. Directory must contain sub-directories
-bin for executables(especially odb.exe) and dlls, include/odb for odb headers and lib for lib files. 
+Install all odb components into some directory and setup environment variable ODB_ROOT=your_odb_installation_directory. 
+Directory must contain sub-directories bin for executables(especially odb.exe) and dlls, 
+include/odb for odb headers and lib for lib files. 
 For example c:\odb\bin, c\odb\include and c:\odb\lib. Note: when you copy odb.exe - do not copy only exe file - you need all directories from archive.
 
 ### Generate project Windows/Linux
-* Generate as usual - each persistent structure in separated file. Simply execute cmake .
-* Generate all persistent structures in one file - cmake . -DAT_ONCE=ON
+* One structure per file. Simply run cmake without options.
+* All persistent structures in one file - set option AT_ONCE=ON. For example cmake . -DAT_ONCE=ON
 

--- a/README
+++ b/README
@@ -1,4 +1,11 @@
 CMake Find Module and UseFile for ODB.
 
-See example for information on useage, i'm too lazy to write documentation right now.
+### Windows ODB installation notes:
+Install all odb components into some directory and setup environment variable ODB_ROOT. Directory must contain sub-directories
+bin for executables(especially odb.exe) and dlls, include/odb for odb headers and lib for lib files. 
+For example c:\odb\bin, c\odb\include and c:\odb\lib. Note: when you copy odb.exe - do not copy only exe file - you need all directories from archive.
+
+### Generate project Windows/Linux
+* Generate as usual - each persistent structure in separated file. Simply execute cmake .
+* Generate all persistent structures in one file - cmake . -DAT_ONCE=ON
 

--- a/cmake/Modules/FindODB.cmake
+++ b/cmake/Modules/FindODB.cmake
@@ -69,7 +69,7 @@ endfunction()
 
 pkg_check_modules(PC_LIBODB QUIET "libodb")
 
-#set(ODB_LIBRARY_PATH "" CACHE STRING "Common library search hint for all ODB libs")
+set(ODB_LIBRARY_PATH "" CACHE STRING "Common library search hint for all ODB libs")
 
 find_path(libodb_INCLUDE_DIR
 	NAMES odb/version.hxx

--- a/cmake/Modules/FindODB.cmake
+++ b/cmake/Modules/FindODB.cmake
@@ -69,7 +69,7 @@ endfunction()
 
 pkg_check_modules(PC_LIBODB QUIET "libodb")
 
-set(ODB_LIBRARY_PATH "" CACHE STRING "Common library search hint for all ODB libs")
+#set(ODB_LIBRARY_PATH "" CACHE STRING "Common library search hint for all ODB libs")
 
 find_path(libodb_INCLUDE_DIR
 	NAMES odb/version.hxx

--- a/cmake/Modules/UseODB.cmake
+++ b/cmake/Modules/UseODB.cmake
@@ -141,55 +141,55 @@ function(odb_compile outvar)
 	file(REMOVE_RECURSE "${ODB_COMPILE_OUTPUT_DIR}")
 	file(MAKE_DIRECTORY "${ODB_COMPILE_OUTPUT_DIR}")
 
-  if(PARAM_INPUT_NAME)
-    get_filename_component(fname "${PARAM_INPUT_NAME}" NAME_WE)
-            set(outputs)
+	if(PARAM_INPUT_NAME)
+		get_filename_component(fname "${PARAM_INPUT_NAME}" NAME_WE)
+			set(outputs)
 
-	  foreach(sfx ${ODB_COMPILE_FILE_SUFFIX})
-		  string(REGEX REPLACE ":.*$" "" pfx "${sfx}")
-		  string(REGEX REPLACE "^.*:" "" sfx "${sfx}")
+		foreach(sfx ${ODB_COMPILE_FILE_SUFFIX})
+			string(REGEX REPLACE ":.*$" "" pfx "${sfx}")
+			string(REGEX REPLACE "^.*:" "" sfx "${sfx}")
 
-		  if(NOT "${PARAM_MULTI_DATABASE}" MATCHES "static" OR NOT "${pfx}" MATCHES "common")
-			  set(output "${ODB_COMPILE_OUTPUT_DIR}/${fname}${sfx}${ODB_COMPILE_SOURCE_SUFFIX}")
-			  list(APPEND ${outvar} "${output}")
-			  list(APPEND outputs "${output}")
-		  endif()
-	  endforeach()
+			if(NOT "${PARAM_MULTI_DATABASE}" MATCHES "static" OR NOT "${pfx}" MATCHES "common")
+				set(output "${ODB_COMPILE_OUTPUT_DIR}/${fname}${sfx}${ODB_COMPILE_SOURCE_SUFFIX}")
+				list(APPEND ${outvar} "${output}")
+				list(APPEND outputs "${output}")
+			endif()
+		endforeach()
+		
+		add_custom_command(OUTPUT ${outputs}
+			COMMAND ${ODB_EXECUTABLE} ${ODB_ARGS} ${PARAM_FILES}
+			DEPENDS ${PARAM_FILES}
+			WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+			VERBATIM)
+	else()
+		foreach(input ${PARAM_FILES})
+			get_filename_component(fname "${input}" NAME_WE)
+			set(outputs)
 
-    add_custom_command(OUTPUT ${outputs}
-      COMMAND ${ODB_EXECUTABLE} ${ODB_ARGS} ${PARAM_FILES}
-      DEPENDS ${PARAM_FILES}
-            WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
-            VERBATIM)
-  else()
-	  foreach(input ${PARAM_FILES})
-		  get_filename_component(fname "${input}" NAME_WE)
-		  set(outputs)
+			foreach(sfx ${ODB_COMPILE_FILE_SUFFIX})
+				string(REGEX REPLACE ":.*$" "" pfx "${sfx}")
+				string(REGEX REPLACE "^.*:" "" sfx "${sfx}")
 
-		  foreach(sfx ${ODB_COMPILE_FILE_SUFFIX})
-			  string(REGEX REPLACE ":.*$" "" pfx "${sfx}")
-			  string(REGEX REPLACE "^.*:" "" sfx "${sfx}")
+				if(NOT "${PARAM_MULTI_DATABASE}" MATCHES "static" OR NOT "${pfx}" MATCHES "common")
+					set(output "${ODB_COMPILE_OUTPUT_DIR}/${fname}${sfx}${ODB_COMPILE_SOURCE_SUFFIX}")
+					list(APPEND ${outvar} "${output}")
+					list(APPEND outputs "${output}")
+				endif()
+			endforeach()
 
-			  if(NOT "${PARAM_MULTI_DATABASE}" MATCHES "static" OR NOT "${pfx}" MATCHES "common")
-				  set(output "${ODB_COMPILE_OUTPUT_DIR}/${fname}${sfx}${ODB_COMPILE_SOURCE_SUFFIX}")
-				  list(APPEND ${outvar} "${output}")
-				  list(APPEND outputs "${output}")
-			  endif()
-		  endforeach()
+		if(ODB_COMPILE_DEBUG)
+			set(_msg "${ODB_EXECUTABLE} ${ODB_ARGS} ${input}")
+			string(REPLACE ";" " " _msg "${_msg}")
+			message(STATUS "${_msg}")
+		endif()
 
-		  if(ODB_COMPILE_DEBUG)
-			  set(_msg "${ODB_EXECUTABLE} ${ODB_ARGS} ${input}")
-			  string(REPLACE ";" " " _msg "${_msg}")
-			  message(STATUS "${_msg}")
-		  endif()
-
-		  add_custom_command(OUTPUT ${outputs}
-			  COMMAND ${ODB_EXECUTABLE} ${ODB_ARGS} "${input}"
-			  DEPENDS "${input}"
-			  WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
-			  VERBATIM)
-	  endforeach()
-  endif()
+		add_custom_command(OUTPUT ${outputs}
+			COMMAND ${ODB_EXECUTABLE} ${ODB_ARGS} "${input}"
+			DEPENDS "${input}"
+			WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+			VERBATIM)
+		endforeach()
+	endif()
 
 	set(${outvar} ${${outvar}} PARENT_SCOPE)
 endfunction()

--- a/driver.cpp
+++ b/driver.cpp
@@ -10,8 +10,14 @@
 #include "database.h" // create_database
 
 #include "person.h"
-#include "person_odb.h"
+#include "employee.h"
 
+#ifdef AT_ONCE
+	#include "personal_odb.h"
+#else
+#include "person_odb.h"
+#include "employee_odb.h"
+#endif
 using namespace std;
 using namespace odb::core;
 

--- a/employee.h
+++ b/employee.h
@@ -1,0 +1,32 @@
+// file      : hello/employee.hxx
+// copyright : not copyrighted - public domain
+
+#ifndef EMPLOYEE_HXX
+#define EMPLOYEE_HXX
+
+
+#include <string>
+#include <cstddef> // std::size_t
+
+#include <odb/core.hxx>
+
+#pragma db object
+class employee
+{
+public:
+  std::string position() const { return position_; }
+  unsigned short experience() const { return experience_; }  
+
+private:
+  friend class odb::access;
+
+  employee () {}
+
+  #pragma db id auto
+  unsigned long id_;
+
+  std::string position_;
+  unsigned short experience_;
+};
+
+#endif // EMPLOYEE_HXX


### PR DESCRIPTION
AT_ONCE and INPUT_NAME parameters to build all persistent structures into single source, useful for schema creation/migration. Windows support using ODB_ROOT variable for base path.
